### PR TITLE
Revert queries to pre-#298 changes

### DIFF
--- a/http_server/fns/query_fns.php
+++ b/http_server/fns/query_fns.php
@@ -8,9 +8,9 @@ require_once __DIR__ . '/../queries/users/user_select_hash_by_name.php';
 require_once __DIR__ . '/../queries/users/user_apply_temp_pass.php';
 
 // user selection queries
-require_once __DIR__ . '/../queries/users/user_select.php'; // select full user by id
-require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // select full user by name
-require_once __DIR__ . '/../queries/users/user_select_hash_by_name.php'; // select full user (with hashes) by name
+require_once __DIR__ . '/../queries/users/user_select.php'; // select user (no hashes) by id
+require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // select user (no hashes) by name
+require_once __DIR__ . '/../queries/users/user_select_full_by_name.php'; // select full user (with hashes) by name
 require_once __DIR__ . '/../queries/users/name_to_id.php'; // name -> id
 require_once __DIR__ . '/../queries/users/id_to_name.php'; // id -> name
 
@@ -32,7 +32,7 @@ function pass_login($pdo, $name, $password)
     }
 
     // load the user row
-    $user = user_select_hash_by_name($pdo, $name);
+    $user = user_select_full_by_name($pdo, $name);
 
     // check the password
     if (!password_verify(sha1($password), $user->pass_hash)) {

--- a/http_server/fns/query_fns.php
+++ b/http_server/fns/query_fns.php
@@ -42,12 +42,13 @@ function pass_login($pdo, $name, $password)
             throw new Exception('That username / password combination was not found.');
         }
     }
+    
+    // don't save hashes to memory
+    unset($user->pass_hash);
+    unset($user->temp_pass_hash);
 
     // check to see if they're banned
     check_if_banned($pdo, $user->user_id, $ip);
-
-    // respect changes to capitalization
-    $user = user_select_hash_by_name($pdo, $user->user_id);
 
     // done
     return $user;

--- a/http_server/fns/query_fns.php
+++ b/http_server/fns/query_fns.php
@@ -10,8 +10,10 @@ require_once __DIR__ . '/../queries/users/user_apply_temp_pass.php';
 // user selection queries
 require_once __DIR__ . '/../queries/users/user_select.php'; // select full user by id
 require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // select full user by name
+require_once __DIR__ . '/../queries/users/user_select_hash_by_name.php'; // select full user (with hashes) by name
 require_once __DIR__ . '/../queries/users/name_to_id.php'; // name -> id
 require_once __DIR__ . '/../queries/users/id_to_name.php'; // id -> name
+
 function pass_login($pdo, $name, $password)
 {
 
@@ -45,7 +47,7 @@ function pass_login($pdo, $name, $password)
     check_if_banned($pdo, $user->user_id, $ip);
 
     // respect changes to capitalization
-    $user = user_select($pdo, $user->user_id);
+    $user = user_select_hash_by_name($pdo, $user->user_id);
 
     // done
     return $user;

--- a/http_server/queries/users/user_select_full_by_name.php
+++ b/http_server/queries/users/user_select_full_by_name.php
@@ -1,6 +1,6 @@
 <?php
 
-function user_select_hash_by_name($pdo, $name)
+function user_select_full_by_name($pdo, $name)
 {
     $stmt = $pdo->prepare('
         SELECT *

--- a/http_server/queries/users/user_select_hash_by_name.php
+++ b/http_server/queries/users/user_select_hash_by_name.php
@@ -3,7 +3,7 @@
 function user_select_hash_by_name($pdo, $name)
 {
     $stmt = $pdo->prepare('
-        SELECT pass_hash, temp_pass_hash, user_id
+        SELECT *
           FROM users
          WHERE name = :name
          LIMIT 1


### PR DESCRIPTION
Reverting the `users_select_hash_by_name` query to what it was before my changes, then changing `user_select` in `query_fns.php` back to `users_select_hash_by_name`.